### PR TITLE
Feat: allow churns to recover after being unresolved

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,13 @@ async fn main() -> anyhow::Result<()> {
 
     println!("Wait one minute before starting to resolve records");
 
-    run_churn_loop(published_records, cli.stop_fraction, cli.sleep_duration_ms).await?;
+    run_churn_loop(
+        client,
+        published_records,
+        cli.stop_fraction,
+        cli.sleep_duration_ms,
+    )
+    .await?;
 
     Ok(())
 }
@@ -139,11 +145,11 @@ async fn publish_records(
 }
 
 async fn run_churn_loop(
+    client: Client,
     verified_records: Vec<(PublicKey, Instant)>,
     stop_fraction: f64,
     sleep_duration_ms: u64,
 ) -> anyhow::Result<()> {
-    let client = Client::builder().no_relays().build()?;
     let total_keys = verified_records.len();
     // Map to record the first time a key fails to resolve.
     let mut potential_churn: HashMap<PublicKey, Instant> = HashMap::new();


### PR DESCRIPTION
This PR mark churns when they are first unresolved. But still will keep re-trying to resolve them on all future loops. Records can recover and be marked again as "resolvable". The script ends when 90% of the records are marked as churned.

This PR uses always the same client (publishing and resolving). Using a new client for the resolving loop always leads to failing to resolve the first 15-20 records (at least on my machine).